### PR TITLE
Reject invalid UTF-8 before truncating read_sanitized_line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,13 @@ pub fn read_sanitized_line<R: BufRead>(
                     )));
                 }
 
+                if utf8_error.error_len().is_some() {
+                    return Err(InputError::Io(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        utf8_error,
+                    )));
+                }
+
                 if limit_exhausted {
                     truncated = true;
                     let mut bytes = err.into_bytes();


### PR DESCRIPTION
## Summary
- abort early on Utf8Error reports with `error_len` to keep rejecting invalid byte sequences
- only truncate to the valid UTF-8 prefix when the byte limit is exhausted by an incomplete code point

## Testing
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d11c7df4a4832b9bd7982fb9e42003