### PR TITLE
Limit default workspace members to main crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = ["fuzz"]
+members = [".", "fuzz"]
+default-members = ["."]
 resolver = "2"
 
 [package]


### PR DESCRIPTION
## Summary
- include the root crate in the workspace member list so it can be referenced explicitly
- restrict the workspace default members to the root crate so `cargo test`/`cargo build` skip the fuzz package unless requested

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d12cdb333c832b8f44d48151013aa7