### PR TITLE
Clarify README cargo run command for secure_input

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The workspace root is package-free; invoke binaries and tests through
 `-p secure_input` or by using the default workspace member. For example:
 
 ```bash
-cargo test          # runs in crates/secure_input by default
-cargo run           # builds the demo CLI from crates/secure_input
+cargo test                 # runs in crates/secure_input by default
+cargo run -p secure_input  # builds the demo CLI without the fuzzing toolchain
 ```
 
 ## Fuzzing first steps


### PR DESCRIPTION
## Summary
- clarify the README's run example to pass `-p secure_input` so the CLI can build without fuzzing dependencies

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d15576bfd4832b8deb04dcbd10b477