### PR TITLE
Fix Stage 1 secure_input tutorial compile error

### DIFF
--- a/docs/tutorial/stage01_buggy/crates/secure_input/src/lib.rs
+++ b/docs/tutorial/stage01_buggy/crates/secure_input/src/lib.rs
@@ -91,7 +91,7 @@ pub fn sanitize_text(raw: &str, max_len: usize) -> Result<String, InputError> {
 /// other Unicode whitespace characters survive the trimming step, so callers can
 /// accidentally accept labels that consist entirely of invisible characters.
 pub fn sanitize_display_label(raw: &str, max_len: usize) -> Result<String, InputError> {
-    let trimmed = raw.trim_matches(|ch| matches!(ch, ' ' | '\\t' | '\\n' | '\\r'));
+    let trimmed = raw.trim_matches(|ch| matches!(ch, ' ' | '\t' | '\n' | '\r'));
 
     if trimmed.is_empty() {
         return Err(InputError::Empty);


### PR DESCRIPTION
## Summary
- fix the Stage 1 tutorial copy of `sanitize_display_label` to use valid character escape sequences so the example compiles

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d253e5f234832b8835437da1181618