### PR TITLE
Scale back stage 1 tutorial tests

### DIFF
--- a/docs/tutorial/stage01_buggy/crates/secure_input/src/lib.rs
+++ b/docs/tutorial/stage01_buggy/crates/secure_input/src/lib.rs
@@ -225,43 +225,10 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_text_trims_whitespace() {
-        let result = sanitize_text("  Hello World  \\r\\n", 32).unwrap();
-        assert_eq!(result, "Hello World");
-    }
-
-    #[test]
     fn read_sanitized_line_rejects_long_input() {
         let mut cursor = Cursor::new("six chars\\n");
         let err = read_sanitized_line(&mut cursor, 5).unwrap_err();
         assert!(matches!(err, InputError::TooLong { .. }));
-    }
-
-    #[test]
-    fn read_sanitized_line_discards_overlong_line() {
-        let mut cursor = Cursor::new("abcdefg\\nok\\n");
-        let err = read_sanitized_line(&mut cursor, 5).unwrap_err();
-        assert!(matches!(err, InputError::TooLong { .. }));
-
-        let second = read_sanitized_line(&mut cursor, 5).unwrap();
-        assert_eq!(second, "ok");
-    }
-
-    #[test]
-    fn read_sanitized_line_handles_multi_byte_characters() {
-        let mut cursor = Cursor::new("😀👍\\n");
-        let result = read_sanitized_line(&mut cursor, 4).unwrap();
-        assert_eq!(result, "😀👍");
-    }
-
-    #[test]
-    fn read_sanitized_line_rejects_long_multi_byte_input() {
-        let mut cursor = Cursor::new("😀😀😀\\nok\\n");
-        let err = read_sanitized_line(&mut cursor, 2).unwrap_err();
-        assert!(matches!(err, InputError::TooLong { .. }));
-
-        let second = read_sanitized_line(&mut cursor, 5).unwrap();
-        assert_eq!(second, "ok");
     }
 
     #[test]

--- a/docs/tutorial/stage02_fuzzing/crates/secure_input/src/lib.rs
+++ b/docs/tutorial/stage02_fuzzing/crates/secure_input/src/lib.rs
@@ -91,7 +91,7 @@ pub fn sanitize_text(raw: &str, max_len: usize) -> Result<String, InputError> {
 /// other Unicode whitespace characters survive the trimming step, so callers can
 /// accidentally accept labels that consist entirely of invisible characters.
 pub fn sanitize_display_label(raw: &str, max_len: usize) -> Result<String, InputError> {
-    let trimmed = raw.trim_matches(|ch| matches!(ch, ' ' | '\\t' | '\\n' | '\\r'));
+    let trimmed = raw.trim_matches(|ch| matches!(ch, ' ' | '\t' | '\n' | '\r'));
 
     if trimmed.is_empty() {
         return Err(InputError::Empty);
@@ -225,43 +225,10 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_text_trims_whitespace() {
-        let result = sanitize_text("  Hello World  \\r\\n", 32).unwrap();
-        assert_eq!(result, "Hello World");
-    }
-
-    #[test]
     fn read_sanitized_line_rejects_long_input() {
         let mut cursor = Cursor::new("six chars\\n");
         let err = read_sanitized_line(&mut cursor, 5).unwrap_err();
         assert!(matches!(err, InputError::TooLong { .. }));
-    }
-
-    #[test]
-    fn read_sanitized_line_discards_overlong_line() {
-        let mut cursor = Cursor::new("abcdefg\\nok\\n");
-        let err = read_sanitized_line(&mut cursor, 5).unwrap_err();
-        assert!(matches!(err, InputError::TooLong { .. }));
-
-        let second = read_sanitized_line(&mut cursor, 5).unwrap();
-        assert_eq!(second, "ok");
-    }
-
-    #[test]
-    fn read_sanitized_line_handles_multi_byte_characters() {
-        let mut cursor = Cursor::new("😀👍\\n");
-        let result = read_sanitized_line(&mut cursor, 4).unwrap();
-        assert_eq!(result, "😀👍");
-    }
-
-    #[test]
-    fn read_sanitized_line_rejects_long_multi_byte_input() {
-        let mut cursor = Cursor::new("😀😀😀\\nok\\n");
-        let err = read_sanitized_line(&mut cursor, 2).unwrap_err();
-        assert!(matches!(err, InputError::TooLong { .. }));
-
-        let second = read_sanitized_line(&mut cursor, 5).unwrap();
-        assert_eq!(second, "ok");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pare down the stage01 snapshot's unit tests so the tutorial begins with a minimal suite that keeps the bug hidden
- mirror the lighter test set in stage02 and correct the ASCII whitespace matcher so the snapshot compiles cleanly

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d259b853f0832ba0acefaca608ab15