### PR TITLE
Use Rust 2021 edition and document stable toolchain support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ default-members = ["crates/secure_input"]
 resolver = "2"
 
 [workspace.package]
-edition = "2024"
+edition = "2021"

--- a/crates/secure_input/Cargo.toml
+++ b/crates/secure_input/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "secure_input"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 

--- a/crates/secure_input/src/main.rs
+++ b/crates/secure_input/src/main.rs
@@ -1,4 +1,4 @@
-use secure_input::{InputError, parse_positive_u32, read_sanitized_line};
+use secure_input::{parse_positive_u32, read_sanitized_line, InputError};
 use std::io::{self, Write};
 
 fn main() {

--- a/crates/secure_input/tests/input_handling.rs
+++ b/crates/secure_input/tests/input_handling.rs
@@ -1,4 +1,4 @@
-use secure_input::{InputError, parse_positive_u32, read_sanitized_line, sanitize_text};
+use secure_input::{parse_positive_u32, read_sanitized_line, sanitize_text, InputError};
 use std::io::Cursor;
 
 #[test]

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -65,8 +65,10 @@ command; `cargo-fuzz` automatically loads the previously discovered inputs.
 
 `cargo-fuzz` can delegate execution to AddressSanitizer (ASan) to capture
 memory-corruption issues and emit symbolised backtraces when a crash occurs.
-The sanitiser integration requires the nightly toolchain, a symbolizer binary,
-and a couple of environment variables:
+The fuzz targets build and run on the stable toolchain. ASan still depends on
+the nightly-only `-Zsanitizer=address` flag though, so remaining on stable means
+invoking `cargo fuzz` with `--sanitizer none`. To enable ASan, install a
+symbolizer binary and configure a couple of environment variables on nightly:
 
 ```bash
 rustup toolchain install nightly                   # once per machine

--- a/docs/tutorial/stage02_fuzzing/README.md
+++ b/docs/tutorial/stage02_fuzzing/README.md
@@ -55,7 +55,9 @@ harness then applies `trim()` and observes that the cleaned label becomes empty,
 causing the panic.
 
 To replay the crash deterministically and capture a symbolised stack trace, run
-the sanitizer-aware command from the [fuzzing guide](../../fuzzing.md#symbolised-crash-reports-with-addresssanitizer):
+the sanitizer-aware command from the [fuzzing guide](../../fuzzing.md#symbolised-crash-reports-with-addresssanitizer).
+The fuzz target itself builds on stable; enabling AddressSanitizer still
+requires nightly:
 
 ```bash
 export ASAN_SYMBOLIZER_PATH="$(rustc +nightly --print target-libdir)/../bin/llvm-symbolizer"

--- a/docs/tutorial/stage02_fuzzing/fuzz/Cargo.toml
+++ b/docs/tutorial/stage02_fuzzing/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "secure_input-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2024"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/docs/tutorial/stage03_fix/fuzz/Cargo.toml
+++ b/docs/tutorial/stage03_fix/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "secure_input-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2024"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "secure_input-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2024"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/sanitize_display_label.rs
+++ b/fuzz/fuzz_targets/sanitize_display_label.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use secure_input::{InputError, sanitize_display_label};
+use secure_input::{sanitize_display_label, InputError};
 
 fuzz_target!(|data: &[u8]| {
     if data.is_empty() {


### PR DESCRIPTION
## Summary
- switch the workspace and tutorial fuzz manifests to Rust 2021 so the crates compile on stable
- document that the fuzz targets run on stable while noting AddressSanitizer still needs nightly
- run rustfmt, which re-ordered a few imports in the crate, tests, and fuzz harness

## Testing
- cargo +stable fmt
- cargo +stable check
- cargo +stable fuzz build --sanitizer none sanitize_text
- cargo +stable fuzz build --sanitizer none sanitize_display_label
- cargo +stable fuzz build --sanitizer none read_sanitized_line
- cargo +stable fuzz build --sanitizer none parse_positive_u32

------
https://chatgpt.com/codex/tasks/task_e_68d273ffc8f4832b818cfb2088e5d16a